### PR TITLE
Session

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	// Session Redis라이브러리
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation "org.springframework.session:spring-session-data-redis"
 	// lombok test 라이브러리
 	testImplementation 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
 	// lombok 라이브러리
 	implementation 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	// Session Redis라이브러리
+	implementation "org.springframework.session:spring-session-data-redis"
 	// lombok test 라이브러리
 	testImplementation 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/LearnDocker/LearnDocker/Initializer.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/Initializer.java
@@ -1,0 +1,9 @@
+package com.LearnDocker.LearnDocker;
+
+import org.springframework.session.web.context.AbstractHttpSessionApplicationInitializer;
+
+public class Initializer extends AbstractHttpSessionApplicationInitializer {
+    public Initializer() {
+        super(SessionConfig.class);
+    }
+}

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
@@ -15,7 +15,6 @@ public class SandboxController {
         this.sandboxService = sandboxService;
     }
 
-    @ResponseBody
     @PostMapping(value="start")
     public ResponseEntity<Map<String, Long>> userContainerStart(final HttpServletRequest httpRequest) {
         this.sandboxService.assignUserContainer();

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
@@ -1,6 +1,9 @@
 package com.LearnDocker.LearnDocker;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
@@ -15,7 +18,11 @@ public class SandboxController {
     }
 
     @PostMapping(value="start")
-    public void userContainerStart() {
+    public void userContainerStart(final HttpServletRequest httpRequest) {
         this.sandboxService.assignUserContainer();
+        final HttpSession session = httpRequest.getSession();
+        if (session.getAttribute("Session") == null) {
+            session.setAttribute("Session", "hello");
+        }
     }
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
@@ -2,14 +2,12 @@ package com.LearnDocker.LearnDocker;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import reactor.core.publisher.Mono;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.Map;
 
 @RestController
-@RequestMapping(value="sandbox")
+@RequestMapping(value="api/sandbox")
 public class SandboxController {
 
     private final SandboxService sandboxService;
@@ -17,12 +15,15 @@ public class SandboxController {
         this.sandboxService = sandboxService;
     }
 
+    @ResponseBody
     @PostMapping(value="start")
-    public void userContainerStart(final HttpServletRequest httpRequest) {
+    public ResponseEntity<Map<String, Long>> userContainerStart(final HttpServletRequest httpRequest) {
         this.sandboxService.assignUserContainer();
         final HttpSession session = httpRequest.getSession();
-        if (session.getAttribute("Session") == null) {
-            session.setAttribute("Session", "hello");
-        }
+        long creationTime = session.getCreationTime();
+        long expirationTime = session.getMaxInactiveInterval() * 1000L;
+        long maxAge = creationTime + expirationTime;
+
+        return ResponseEntity.ok(Map.of("endDate", maxAge));
     }
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/SessionConfig.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SessionConfig.java
@@ -1,14 +1,38 @@
 package com.LearnDocker.LearnDocker;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 @Configuration(proxyBeanMethods = false)
 @EnableRedisHttpSession
-public class SessionConfig {
+public class SessionConfig implements BeanClassLoaderAware {
+
+    private ClassLoader loader;
+
     @Bean
     public LettuceConnectionFactory connectionFactory() {
         return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public RedisSerializer<Object> springSessionDefaultRedisSerializer(ObjectMapper objectMapper) {
+        return new GenericJackson2JsonRedisSerializer(objectMapper);
+    }
+
+    // Sprint Security를 활용한 Jackson을 사용할 때 이용 할 Objecct Mapper
+//    private ObjectMapper objectMapper() {
+//        ObjectMapper objectMapper = new ObjectMapper();
+//        objectMapper.registerModules(SecurityJackson2Modules.getModules(this.loader));
+//        return objectMapper;
+//    }
+
+    @Override
+    public void setBeanClassLoader(ClassLoader classLoader) {
+        this.loader = classLoader;
     }
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/SessionConfig.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SessionConfig.java
@@ -9,7 +9,7 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 @Configuration(proxyBeanMethods = false)
-@EnableRedisHttpSession
+@EnableRedisHttpSession(maxInactiveIntervalInSeconds = 14400)
 public class SessionConfig implements BeanClassLoaderAware {
 
     private ClassLoader loader;

--- a/src/main/java/com/LearnDocker/LearnDocker/SessionConfig.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SessionConfig.java
@@ -1,0 +1,14 @@
+package com.LearnDocker.LearnDocker;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+
+@Configuration(proxyBeanMethods = false)
+@EnableRedisHttpSession
+public class SessionConfig {
+    @Bean
+    public LettuceConnectionFactory connectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,7 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.sql.init.mode=always
 
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+
+server.servlet.session.timeout=14400
+spring.session.redis.flush-mode=on_save
+spring.session.redis.namespace=spring:session

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,7 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 server.servlet.session.timeout=14400
 spring.session.redis.flush-mode=on_save
 spring.session.redis.namespace=spring:session
+
+spring.data.redis.host=host.docker.internal
+spring.data.redis.password=
+spring.data.redis.port=6379


### PR DESCRIPTION
# 작업 내용
- Spring Session 적용
- Redis 설정 적용

## 세부 기록
### 1. @ResponseBody 애너테이션
`@ResponseBody`애너테이션의 경우 Response의 Body에 XML 혹은 JSON형식의 데이터를 담을 수 있게 한다. 하지만, `@RestController`의 경우에는 자동으로 `@ResponseBody`애너테이션이 적용된다. 따라서, `@ResponseBody`애터네이션을 적용할 필요는 없다.

### 2. `@RequestHeader`와 `HttpServletRequest`클래스
`@RequestHeader`의 경우 HTTP Request의 Header를 처리하기 위한 클래스로 서버의 Session을 다룰 수 없으며 Header에 대해서만 다룬다. 또한, Header의 Key하나를 지정해 Value를 가져올 수 있다.

ex)

`@RequestHeader("User-agent") String agent`// Header의 User Agent에 대한 Value를 받아온다.

반면, `HttpServletRequest`클래스의 경우 HTTP Request의 Header와 Body 모두 다룰 수 있으며 서버에서의 Session또한 관리할 수 있다는 장점이 있다.

따라서, Session과 이미지 업로드 등의 기능이나 세부적인 접근이 필요할 때는 `HttpServletRequest`객체를 활용하면 된다. Header에 대해 1개의 value만 접근하면 되는 것과 같은 간단한 Request의 처리는 `@RequestHeader`를 활용하면 된다.

### 3. `ResponseEntity`와 `HttpServletResponse`
`ResponseEntity`의 경우 Response를 클라이언트에게 전달할 때 JSON데이터를 전송할 수 있게 해준다. 여기에 더해 HTTP Status code를 전달하고 Header 또한 제어할 수 있다. 추상화가 잘 되어있기 때문에 상대적으로 가독성이 좋고 활용하기에 편리하다.

JSON데이터를 전달할 때 JAVA의 Map객체 인스턴스를 그냥 매개변수로 전달하기만 하면 JSON으로 직렬화되어 전달된다.

반면, `HttpServletResponse`의 경우 상대적으로 낮은 추상화가 되어있기 때문에 `ResponseEntity`와는 동일한 역할을 지니지만 가독성과 활용도는 어렵다.

Body에 데이터를 담아 보낼 때 문자열로 처리되어 전달해야 한다.

### 4. `@EnabledRedisHttpSession`과 `@EnabledRedisIndexedHttpSession`
위 두 애너테이션의 차이는 `index`의 활용 유무에 대한 차이점이 존재한다. `@EnabledRedisIndexedHttpSession`의 경우 인덱스를 활용하기 때문에 상대적으로 조회 성능이 좋다. 하지만, Index를 위해 데이터를 추가적으로 저장해야 하기 때문에 삽입, 삭제, 수정이 빈번하면 오히려 더 좋지 않다.

`@EnabledRedisHttpSession`의 경우 인덱스를 활용하지 않기 때문에 삽입, 삭제, 수정의 경우 더 효율적이나 조회에 있어 데이터가 많은 경우 시간이 상대적으로 더 오래걸릴 수 있다.

> [!Tip]
> 
