### PR TITLE
학습 시작 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ dependencies {
 	// Session Redis라이브러리
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation "org.springframework.session:spring-session-data-redis"
+	// Security Framework
+	implementation "org.springframework.boot:spring-boot-starter-security"
+	implementation "org.springframework.security:spring-security-web"
+	implementation "org.springframework.security:spring-security-config"
 	// lombok test 라이브러리
 	testImplementation 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -29,10 +29,6 @@ dependencies {
 	// Session Redis라이브러리
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation "org.springframework.session:spring-session-data-redis"
-	// Security Framework
-	implementation "org.springframework.boot:spring-boot-starter-security"
-	implementation "org.springframework.security:spring-security-web"
-	implementation "org.springframework.security:spring-security-config"
 	// lombok test 라이브러리
 	testImplementation 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/LearnDocker/LearnDocker/Configuration/AppConfig.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/Configuration/AppConfig.java
@@ -1,4 +1,4 @@
-package com.LearnDocker.LearnDocker;
+package com.LearnDocker.LearnDocker.Configuration;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/LearnDocker/LearnDocker/Initializer.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/Initializer.java
@@ -1,5 +1,6 @@
 package com.LearnDocker.LearnDocker;
 
+import com.LearnDocker.LearnDocker.Configuration.SessionConfig;
 import org.springframework.session.web.context.AbstractHttpSessionApplicationInitializer;
 
 public class Initializer extends AbstractHttpSessionApplicationInitializer {

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpSession;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.Map;
+import java.util.Objects;
 
 @RestController
 @RequestMapping(value="api/sandbox")
@@ -32,7 +33,7 @@ public class SandboxController {
     public void releaseUserSession(final HttpServletRequest httpRequest) {
         final HttpSession session = httpRequest.getSession();
         // 이렇게 Object객체를 String으로 강제 형변환 하는게 좋은 방법인지 알아보기
-        this.sandboxService.releaseUserSession((String)session.getAttribute("containerId"));
+        this.sandboxService.releaseUserSession(Objects.toString(session.getAttribute("containerId"), null));
         session.invalidate();
     }
 

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
@@ -17,12 +17,23 @@ public class SandboxController {
 
     @PostMapping(value="start")
     public ResponseEntity<Map<String, Long>> userContainerStart(final HttpServletRequest httpRequest) {
-        this.sandboxService.assignUserContainer();
         final HttpSession session = httpRequest.getSession();
+        String containerId = this.sandboxService.assignUserContainer();
         long creationTime = session.getCreationTime();
         long expirationTime = session.getMaxInactiveInterval() * 1000L;
         long maxAge = creationTime + expirationTime;
 
+        session.setAttribute("containerId", containerId);
+
         return ResponseEntity.ok(Map.of("endDate", maxAge));
     }
+
+    @DeleteMapping(value="release")
+    public void releaseUserSession(final HttpServletRequest httpRequest) {
+        final HttpSession session = httpRequest.getSession();
+        // 이렇게 Object객체를 String으로 강제 형변환 하는게 좋은 방법인지 알아보기
+        this.sandboxService.releaseUserSession((String)session.getAttribute("containerId"));
+        session.invalidate();
+    }
+
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
@@ -42,15 +42,27 @@ public class SandboxService {
     public void startUserContainer(String containerId) {
         // Start Container
         this.webClient.build()
-            .post()
-            .uri("/containers/" + containerId + "/start")
-            .contentType(MediaType.APPLICATION_JSON)
-            .retrieve()
-            .bodyToMono(String.class).subscribe(result -> System.out.println(result));
+                .post()
+                .uri("/containers/" + containerId + "/start")
+                .contentType(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .toBodilessEntity()
+                .block();
     }
 
-    public void assignUserContainer() {
+    public String assignUserContainer() {
         String containerId = createUserContainer().block();
         startUserContainer(containerId);
+
+        return containerId;
+    }
+
+    public void releaseUserSession(String containerId) {
+        this.webClient.build()
+                .delete()
+                .uri("containers/" + containerId + "?force=true&v=true")
+                .retrieve()
+                .toBodilessEntity()
+                .subscribe();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+server.port=3000
+
 spring.application.name=LearnDocker
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/learndocker?serverTimezone=Asia/Seoul


### PR DESCRIPTION
# 작업 내용
- Spring Security Redirection문제로 인한 패키지 의존성 삭제
- Spring Container Start를 위한 메소드 설정(toBodilessEntity, bodyToMono 등)
- Spring Container Stop을 위한 Controller, Service구현
- Session에 containerId저장 및 Session삭제 기능 추가

## 세부 기록
### 1. Spring Security
Spring Security는 의존성에 추가하기만 해도 `/login`페이지로 리디렉션된다. 이것이 Spring Security의 인가를 위한 기능인 것 같다. url path에 따라서 `/login`으로의 redirection이 안되도록 설정할 수 있다고 하니 인가의 관점에서 나중에 학습할 필요가 있을 것 같다.

### 2. HttpSession에 대하여
HttpSession클래스의 인스턴스는 생각보다 많은 기능을 제공한다. NestJS에서 직접 구현한 세션 테이블을 자동으로 생성해주며 해당 Session에 자신이 담고싶은 데이터를 넣고 지울 수 있다(session.setAttribute, session.releaseAttribute)

### 3. WebFlux에 대하여
retrieve메소드만으로는 요청이 실행되지 않는다... 그 이유는 알아봐야 한다.

### 4. 형 변환 시
형 변환 시 다른 타입이 반환되는 위험이 발생할 수 있다. `session.getAttribute`메소드는 `Objects`타입의 인스턴스를 반환하는데 이는 최상위 클래스로 다양한 타입의 값들이 반환될 수 있다. 타입을 캐스팅 하기 위해서 안전장치가 반드시 필요하다.
1. `String`의 경우는 `Objects.toString(data, null)`을 활용할 수 있다.
2. `Casting`을 하는 경우 `instanceof`키워드를 활용해 타입을 확인하고 캐스팅한다. 만약 아니라면, 예외로 처리

### 5. `Optional`에 대해서 학습 필요..

