### PR TITLE
Elements api

### DIFF
--- a/src/main/java/com/LearnDocker/LearnDocker/Configuration/AppConfig.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/Configuration/AppConfig.java
@@ -12,6 +12,6 @@ public class AppConfig {
     }
     @Bean(name="ContainerWebClient")
     public WebClient getContainerWebClient() {
-        return WebClient.create("http://localhost:");
+        return WebClient.create("http://localhost");
     }
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/Configuration/AppConfig.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/Configuration/AppConfig.java
@@ -6,8 +6,12 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class AppConfig {
-    @Bean
+    @Bean(name="DockerWebClient")
     public WebClient getWebClient() {
         return WebClient.create("http://localhost:2375");
+    }
+    @Bean(name="ContainerWebClient")
+    public WebClient getContainerWebClient() {
+        return WebClient.create("http://localhost:");
     }
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/Configuration/SessionConfig.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/Configuration/SessionConfig.java
@@ -1,4 +1,4 @@
-package com.LearnDocker.LearnDocker;
+package com.LearnDocker.LearnDocker.Configuration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/LearnDocker/LearnDocker/DTO/ContainerInfo.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/DTO/ContainerInfo.java
@@ -1,0 +1,19 @@
+package com.LearnDocker.LearnDocker.DTO;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class ContainerInfo {
+    @Getter
+    @Setter
+    private String containerId;
+
+    @Getter
+    @Setter
+    private String containerPort;
+
+    public ContainerInfo(String containerId, String containerPort) {
+        this.containerId = containerId;
+        this.containerPort = containerPort;
+    }
+}

--- a/src/main/java/com/LearnDocker/LearnDocker/DTO/Elements.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/DTO/Elements.java
@@ -1,7 +1,11 @@
 package com.LearnDocker.LearnDocker.DTO;
 
+import lombok.Getter;
+
 public class Elements {
+    @Getter
     private Image[] images;
+    @Getter
     private Container[] containers;
 
     public Elements(Image[] images, Container[] containers) {
@@ -10,7 +14,9 @@ public class Elements {
     }
 
     public static class Image {
+        @Getter
         private String id;
+        @Getter
         private String name;
 
         public Image(String id, String name) {
@@ -20,9 +26,13 @@ public class Elements {
     }
 
     public static class Container {
+        @Getter
         private String id;
+        @Getter
         private String name;
+        @Getter
         private String status;
+        @Getter
         private String image;
 
         public Container(String id, String name, String status, String image) {

--- a/src/main/java/com/LearnDocker/LearnDocker/DTO/Elements.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/DTO/Elements.java
@@ -1,0 +1,37 @@
+package com.LearnDocker.LearnDocker.DTO;
+
+public class Elements {
+    private Image[] images;
+    private Container[] containers;
+
+    public Elements(Image[] images, Container[] containers) {
+        this.images = images;
+        this.containers = containers;
+    }
+
+    public static class Image {
+        private String id;
+        private String name;
+
+        public Image(String id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+
+    public static class Container {
+        private String id;
+        private String name;
+        private String status;
+        private String image;
+
+        public Container(String id, String name, String status, String image) {
+            this.id = id;
+            this.name = name;
+            this.status = status;
+            this.image = image;
+        }
+
+    }
+}
+

--- a/src/main/java/com/LearnDocker/LearnDocker/Quiz.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/Quiz.java
@@ -13,6 +13,9 @@ public class Quiz {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name="title")
+    private String title;
+
     @Column(name="content", nullable=false)
     private String content;
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/QuizController.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/QuizController.java
@@ -1,21 +1,32 @@
 package com.LearnDocker.LearnDocker;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Objects;
+
 @RestController
-@RequestMapping(value="/quiz") // Base Path 설정
+@RequestMapping(value="api/quiz")
 public class QuizController {
     private QuizService quizService;
+
     public QuizController(QuizService quizService) {
-        // Quiz를 가져오기 위한 Service 의존성 주입
         this.quizService = quizService;
     }
     
     @GetMapping(value="/{quizId}")
-    public String getQuizById(@PathVariable(value="quizId") long quizId) {
+    public String getQuizById(@PathVariable(value="quizId") int quizId) {
         return this.quizService.getQuizById(quizId);
+    }
+
+    @GetMapping(value="/{quizId}/access")
+    public void accessQuiz(@PathVariable(value="quizId") int quizId, HttpServletRequest request) {
+        HttpSession session = request.getSession();
+        int level = Integer.parseInt(Objects.toString(session.getAttribute("level"), null));
+        this.quizService.accessQuiz(quizId, level);
     }
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/QuizRepository.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/QuizRepository.java
@@ -2,5 +2,5 @@ package com.LearnDocker.LearnDocker;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface QuizRepository extends JpaRepository<Quiz, Long> {
+public interface QuizRepository extends JpaRepository<Quiz, Integer> {
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/QuizService.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/QuizService.java
@@ -1,6 +1,8 @@
 package com.LearnDocker.LearnDocker;
 
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
+import org.springframework.web.ErrorResponseException;
 
 @Service
 public class QuizService {
@@ -10,7 +12,15 @@ public class QuizService {
         this.quizRepository = quizRepository;
     }
 
-    public String getQuizById(long quizId) {
+    public String getQuizById(int quizId) {
+        String quiz = this.quizRepository.findById(quizId).toString();
+        System.out.println(quiz);
         return this.quizRepository.findById(quizId).toString();
+    }
+
+    public void accessQuiz(int quizId, int level) {
+        if (quizId < level) {
+            throw new ErrorResponseException(HttpStatusCode.valueOf(400));
+        }
     }
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
@@ -1,5 +1,6 @@
 package com.LearnDocker.LearnDocker;
 
+import com.LearnDocker.LearnDocker.DTO.ContainerInfo;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.http.ResponseEntity;
@@ -19,12 +20,13 @@ public class SandboxController {
     @PostMapping(value="start")
     public ResponseEntity<Map<String, Long>> userContainerStart(final HttpServletRequest httpRequest) {
         final HttpSession session = httpRequest.getSession();
-        String containerId = this.sandboxService.assignUserContainer();
+        ContainerInfo containerInfo = this.sandboxService.assignUserContainer();
         long creationTime = session.getCreationTime();
         long expirationTime = session.getMaxInactiveInterval() * 1000L;
         long maxAge = creationTime + expirationTime;
 
-        session.setAttribute("containerId", containerId);
+        session.setAttribute("containerId", containerInfo.getContainerId());
+        session.setAttribute("containerPort", containerInfo.getContainerPort());
         session.setAttribute("level", 0);
 
         return ResponseEntity.ok(Map.of("endDate", maxAge));
@@ -36,6 +38,13 @@ public class SandboxController {
         // 이렇게 Object객체를 String으로 강제 형변환 하는게 좋은 방법인지 알아보기
         this.sandboxService.releaseUserSession(Objects.toString(session.getAttribute("containerId"), null));
         session.invalidate();
+    }
+
+    @GetMapping(value="hostStatus")
+    public String getHostStatus(final HttpServletRequest httpRequest) {
+        final HttpSession session = httpRequest.getSession();
+        final int containerPort = Integer.parseInt(Objects.toString(session.getAttribute("containerPort")));
+        return this.sandboxService.getHostStatus(containerPort);
     }
 
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
@@ -1,6 +1,7 @@
 package com.LearnDocker.LearnDocker;
 
 import com.LearnDocker.LearnDocker.DTO.ContainerInfo;
+import com.LearnDocker.LearnDocker.DTO.Elements;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.http.ResponseEntity;
@@ -45,6 +46,14 @@ public class SandboxController {
         final HttpSession session = httpRequest.getSession();
         final int containerPort = Integer.parseInt(Objects.toString(session.getAttribute("containerPort")));
         return this.sandboxService.getHostStatus(containerPort);
+    }
+
+    @GetMapping(value="elements")
+    public ResponseEntity<Elements> getUserContainerImages(HttpServletRequest httpServletRequest) {
+            final HttpSession session = httpServletRequest.getSession();
+            final int containerPort = Integer.parseInt(Objects.toString(session.getAttribute("containerPort")));
+            final Elements elements = this.sandboxService.getUserContainersImages(containerPort);
+            return ResponseEntity.ok(elements);
     }
 
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
@@ -25,6 +25,7 @@ public class SandboxController {
         long maxAge = creationTime + expirationTime;
 
         session.setAttribute("containerId", containerId);
+        session.setAttribute("level", 0);
 
         return ResponseEntity.ok(Map.of("endDate", maxAge));
     }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,8 +1,98 @@
-INSERT INTO quiz (content) VALUES (
-                                      CONCAT(
-                                              'Docker의 첫 걸음을 시작해볼까요?\n',
-                                              'learndocker.io에서 제공하는 hello-world 이미지를 가져와보세요.\n\n',
-                                              '1. docker pull 명령어를 사용하여 learndocker.io/hello-world 이미지를 다운로드하세요.\n',
-                                              '2. 이미지가 성공적으로 다운로드되면 자동으로 로컬 시스템에 저장됩니다.\n'
-                                      )
-                                  );
+INSERT INTO quiz (title, content) VALUES (
+    'Docker Image 가져오기',
+    CONCAT(
+        'Docker의 첫 걸음을 시작해볼까요?\n',
+        'learndocker.io에서 제공하는 hello-world 이미지를 가져와보세요.\n\n',
+        '1. docker pull 명령어를 사용하여 learndocker.io/hello-world 이미지를 다운로드하세요.\n',
+        '2. 이미지가 성공적으로 다운로드되면 자동으로 로컬 시스템에 저장됩니다.\n'
+    )
+);
+
+INSERT INTO quiz (title, content) VALUES (
+    'Docker image 목록 확인하기',
+    CONCAT(
+        '로컬 시스템에 저장된 Docker 이미지들을 확인해볼까요?\n\n',
+        '1. docker images 명령어를 사용하여 현재 시스템에 있는 모든 Docker 이미지를 조회하세요.\n',
+        '2. 명령어 실행 후 출력된 결과에서 learndocker.io/hello-world 이미지 ID를 앞 4자리 이상 입력하세요.\n',
+        '3. 답안란은 페이지 우측 하단에 있습니다.\n'
+    )
+);
+
+INSERT INTO quiz (title, content) VALUES (
+    'Docker Image 삭제하기',
+    CONCAT(
+        '더 이상 필요하지 않은 Docker 이미지를 삭제하는 방법을 알아봅시다.\n\n',
+        '1. docker rmi 명령어를 사용하여 learndocker.io/hello-world 이미지를 삭제하세요.\n',
+        '2. 삭제 후 docker images 명령어로 이미지가 정상적으로 삭제되었는지 확인하세요.\n'
+    )
+);
+
+INSERT INTO quiz (title, content) VALUES (
+    'Container 생성하기',
+    CONCAT(
+        'Docker 이미지를 기반으로 컨테이너를 생성해봅시다.\n\n',
+        '1. docker create 명령어를 사용하여 learndocker.io/hello-world 이미지로부터 컨테이너를 생성하세요.\n'
+    )
+);
+
+INSERT INTO quiz (title, content) VALUES (
+    'Container 실행하기',
+    CONCAT(
+        '생성된 컨테이너를 실행해보겠습니다.\n\n',
+        '1. docker start 명령어를 사용하여 이전 단계에서 생성한 컨테이너를 실행하세요.\n',
+        '2. 컨테이너 ID나 이름을 사용하여 실행할 수 있습니다.\n',
+        '3. 실행 후 터미널에 표시되는 "Answer: " 다음에 나오는 값을 입력해주세요.\n',
+        '4. 답안란은 페이지 우측 하단에 있습니다.\n'
+    )
+);
+
+
+INSERT INTO quiz (title, content) VALUES (
+    'Container 생성 및 실행하기',
+    CONCAT(
+        '컨테이너의 생성과 실행을 한 번에 수행해봅시다.\n\n',
+        '1. docker run 명령어를 사용하여 learndocker.io/joke 이미지로 컨테이너를 생성하고 실행하세요.\n',
+        '2. 단 detach 모드로 실행해야 합니다.\n',
+        '3. 이 명령어는 create와 start를 연속으로 실행하는 것과 같은 효과입니다.\n'
+    )
+);
+
+INSERT INTO quiz (title, content) VALUES (
+    'Container 로그 확인하기',
+    CONCAT(
+        'detach로 실행 된 container 로그를 확인해보겠습니다.\n\n',
+        '1. docker ps -a 명령어를 사용하여 모든 컨테이너 목록을 확인하세요.\n',
+        '2. learndocker.io/joke 컨테이너의 로그를 확인하세요\n',
+        '3. 실행 후 터미널에 표시되는 문제를 보고, 띄어쓰기 없이 한글로 답을 입력해주세요.\n',
+        '4. 답안란은 페이지 우측 하단에 있습니다.\n'
+    )
+);
+
+INSERT INTO quiz (title, content) VALUES (
+    'Container 목록 확인하기',
+    CONCAT(
+        '실행 중이거나 중지된 모든 컨테이너를 확인해봅시다.\n\n',
+        '1. docker ps -a 명령어를 사용하여 모든 컨테이너 목록을 확인하세요.\n',
+        '2. joke 이미지로 만든 컨테이너의 ID 최소 앞 4자리를 입력하세요.\n',
+        '3. 답안란은 페이지 우측 하단에 있습니다.\n'
+    )
+);
+
+INSERT INTO quiz (title, content) VALUES (
+    'Container 중지하기',
+    CONCAT(
+        '실행 중인 컨테이너를 중지해보겠습니다.\n\n',
+        '1. docker stop 명령어를 사용하여 실행 중인 모든 컨테이너를 중지하세요.\n',
+        '2. 컨테이너가 중지되면 상태가 Exited로 변경됩니다.\n'
+    )
+);
+
+INSERT INTO quiz (title, content) VALUES (
+    'Container 삭제하기',
+    CONCAT(
+        '더 이상 필요하지 않은 컨테이너를 삭제해봅시다.\n\n',
+        '1. docker rm 명령어를 사용하여 모든 컨테이너를 삭제하세요.\n',
+        '2. 컨테이너가 실행 중인 경우 먼저 중지한 후 삭제해야 합니다.\n',
+        '3. 삭제 후 docker ps -a로 확인해보세요.\n'
+    )
+);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,5 +1,6 @@
 DROP TABLE IF EXISTS quiz;
 CREATE TABLE quiz (
-                      id INT AUTO_INCREMENT PRIMARY KEY,
-                      content TEXT NOT NULL
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(30),
+    content TEXT NOT NULL
 );


### PR DESCRIPTION
# 작업 내용
- `Elements`, `Image`, `Container` DTO객체 생성
- `/api/sandbox/elements` url 요청에 대한 처리를 위한 Controller, Service 계층 구현
- `Image` DTO 객체로 parsing하는 메소드
- `Container` DTO 객체로 parsing하는 메소드

## 세부 기록
### 1. `WebClient`의 `uri`
기존에 사용자의 컨테이너 포트 번호로 접속하는 uri를 위해 `ContainerWebClient`를 생성하도록 
``` Java
@Bean(name="ContainerWebClient")
public WebClient getContainerWebClient() {
    return WebClient.create("http://localhost:");
}
```
위와 같이 `:`을 마지막에 붙였다. 경로도 맞추고 했지만, `java.net.ConnectException: Connection refused: no further information` 이런 에러가 발생했다. 연결 실패...

이 문제를 해결하기 위해서는 `uriBuilder`를 활용해야 했다.

``` Java
@Bean(name="ContainerWebClient")
public WebClient getContainerWebClient() {
    return WebClient.create("http://localhost");
}
```

이렇게 변경하고

``` Java
String responseImages = this.containerWebClient.build()
                .get()
                .uri(uriBuilder -> uriBuilder.port(containerPort).path("/images/json").build())
                .retrieve()
                .bodyToMono(String.class)
                .block();
```

위와 같이 `WebClient`의 uri 지정 방식을 builder패턴을 활용해 하면 된다.
> [!Tip]
> **`uriBuilder`를 활용하는 방법**
> 
> url 지정 시 `port`, `path` 외에도 query parameter를 위한 `queryParam` 메소드 또한 존재한다.
> ex) `uri(uriBuilder -> uriBuilder.port(containerPort).path("/containers/json").queryParam("all", "true").build()`로 코드를 짤 수 있다.

### 2. `Collection`의 `toArray`메소드

Collection 인스턴스를 `Array`형태로 반하기 위한 함수인 `toArray`메소드를 활용하기 위해서는 매개 변수로 `Array`에 저장될 요소의 인스턴스를 전달해야 한다.
ex)
``` Java
List<Image> imageList = new ArrayList<>();
Image[] images = imageList.toArray(new Image[0]);
```
위와 같이 변환할 수 있다. 매개 변수로 전달된 `new Image[0]`인스턴스는 `toArray`메소드에서 **제네릭 타입**으로 활용하기 위해 전달된다.

따라서, `[0]`은 그냥 인스턴스 생성을 위한 조건을 만족시키기 위해 사용된다.

### 3. `JsonNode`클래스는 순회가 가능하다.
만약, `JsonNode` 클래스의 인스턴스의 최상위 타입이 List라면 `for-each`문으로 순회가 가능하다.

예를 들자면
``` JSON
[
    {
        "id": "sha256:5568fddd4f66008ebae555bfee3e999a8f8e6516fbe974e0af11013e83e241fd",
        "name": "mysql"
    }
]
```
> [!Tip] 
> **객체인데 `for - each`문을 사용할 수 있는 이유**
> 
> 형태의 JSON은 현재 최상위 타입은 배열이다. 따라서, `objectMapper.readTree(json);` 방식으로 생성된 `JsonNode`의 최상위 타입이 배열이라면, `ArrayNode`인스턴스를 반환받는다. `ArrayNode`클래스는 `Iterable<JsonNode>`인터페이스를 구현하기 때문에 `for - each`문을 순회할 수 있다.






