### PR TITLE
Quiz Page API 및 NonBlocking구현

### DIFF
--- a/src/main/java/com/LearnDocker/LearnDocker/Configuration/AppConfig.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/Configuration/AppConfig.java
@@ -1,5 +1,6 @@
 package com.LearnDocker.LearnDocker.Configuration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -10,8 +11,14 @@ public class AppConfig {
     public WebClient getWebClient() {
         return WebClient.create("http://localhost:2375");
     }
+
     @Bean(name="ContainerWebClient")
     public WebClient getContainerWebClient() {
         return WebClient.create("http://localhost");
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
     }
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/QuizController.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/QuizController.java
@@ -2,6 +2,7 @@ package com.LearnDocker.LearnDocker;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,8 +20,9 @@ public class QuizController {
     }
     
     @GetMapping(value="/{quizId}")
-    public String getQuizById(@PathVariable(value="quizId") int quizId) {
-        return this.quizService.getQuizById(quizId);
+    public ResponseEntity<Quiz> getQuizById(@PathVariable(value="quizId") int quizId) {
+        Quiz quiz = this.quizService.getQuizById(quizId);
+        return ResponseEntity.ok(quiz);
     }
 
     @GetMapping(value="/{quizId}/access")

--- a/src/main/java/com/LearnDocker/LearnDocker/QuizService.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/QuizService.java
@@ -1,8 +1,10 @@
 package com.LearnDocker.LearnDocker;
 
-import org.springframework.http.HttpStatusCode;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.ErrorResponseException;
+
+import java.util.Optional;
 
 @Service
 public class QuizService {
@@ -12,15 +14,14 @@ public class QuizService {
         this.quizRepository = quizRepository;
     }
 
-    public String getQuizById(int quizId) {
-        String quiz = this.quizRepository.findById(quizId).toString();
-        System.out.println(quiz);
-        return this.quizRepository.findById(quizId).toString();
+    public Quiz getQuizById(int quizId) {
+        Optional<Quiz> optionalQuiz = this.quizRepository.findById(quizId);
+        return optionalQuiz.orElse(null);
     }
 
     public void accessQuiz(int quizId, int level) {
         if (quizId < level) {
-            throw new ErrorResponseException(HttpStatusCode.valueOf(400));
+            throw new ErrorResponseException(HttpStatus.BAD_REQUEST);
         }
     }
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
@@ -38,9 +38,9 @@ public class SandboxController {
     }
 
     @DeleteMapping(value="release")
-    public void releaseUserSession(final HttpServletRequest httpRequest) {
+    public Mono<Void> releaseUserSession(final HttpServletRequest httpRequest) {
         final HttpSession session = httpRequest.getSession();
-        Mono.justOrEmpty(session.getAttribute("containerId"))
+        return Mono.justOrEmpty(session.getAttribute("containerId"))
                 .map(Objects::toString)
                 .flatMap(this.sandboxService::releaseUserSession)
                 .then(Mono.fromRunnable(session::invalidate));

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
@@ -40,9 +40,10 @@ public class SandboxController {
     @DeleteMapping(value="release")
     public void releaseUserSession(final HttpServletRequest httpRequest) {
         final HttpSession session = httpRequest.getSession();
-        // 이렇게 Object객체를 String으로 강제 형변환 하는게 좋은 방법인지 알아보기
-        this.sandboxService.releaseUserSession(Objects.toString(session.getAttribute("containerId"), null));
-        session.invalidate();
+        Mono.justOrEmpty(session.getAttribute("containerId"))
+                .map(Objects::toString)
+                .flatMap(this.sandboxService::releaseUserSession)
+                .then(Mono.fromRunnable(session::invalidate));
     }
 
     @GetMapping(value="hostStatus")

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
@@ -57,11 +57,13 @@ public class SandboxController {
     }
 
     @GetMapping(value="elements")
-    public ResponseEntity<Elements> getUserContainerImages(HttpServletRequest httpServletRequest) {
+    public Mono<ResponseEntity<Elements>> getUserContainerImages(HttpServletRequest httpServletRequest) {
             final HttpSession session = httpServletRequest.getSession();
-            final int containerPort = Integer.parseInt(Objects.toString(session.getAttribute("containerPort")));
-            final Elements elements = this.sandboxService.getUserContainersImages(containerPort);
-            return ResponseEntity.ok(elements);
+            return Mono.justOrEmpty(session.getAttribute("containerPort"))
+                    .map(Objects::toString)
+                    .map(Integer::parseInt)
+                    .flatMap(this.sandboxService::getUserContainersImages)
+                    .map(ResponseEntity::ok);
     }
 
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
@@ -47,10 +47,13 @@ public class SandboxController {
     }
 
     @GetMapping(value="hostStatus")
-    public String getHostStatus(final HttpServletRequest httpRequest) {
+    public Mono<ResponseEntity<String>> getHostStatus(final HttpServletRequest httpRequest) {
         final HttpSession session = httpRequest.getSession();
-        final int containerPort = Integer.parseInt(Objects.toString(session.getAttribute("containerPort")));
-        return this.sandboxService.getHostStatus(containerPort);
+        return Mono.justOrEmpty(session.getAttribute("containerPort"))
+                .map(containerPort ->
+                    Integer.parseInt(Objects.toString(containerPort, "0")))
+                .flatMap(this.sandboxService::getHostStatus)
+                .map(ResponseEntity::ok);
     }
 
     @GetMapping(value="elements")

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
@@ -113,26 +113,25 @@ public class SandboxService {
     }
 
     public Mono<Elements> getUserContainersImages(int containerPort) {
-        Mono<String> imagesMono = this.containerWebClient.build()
+        Mono<Elements.Image[]> imagesMono = this.containerWebClient.build()
                 .get()
                 .uri(uriBuilder -> uriBuilder.port(containerPort).path("/images/json").build())
                 .retrieve()
-                .bodyToMono(String.class);
+                .bodyToMono(String.class)
+                .map(this::parseImages);
 
-        return imagesMono.map(this::parseImages)
-                .flatMap(images ->
-                    this.containerWebClient.build()
-                            .get()
-                            .uri(uriBuilder -> uriBuilder
-                                    .port(containerPort)
-                                    .path("/containers/json")
-                                    .queryParam("all", "true")
-                                    .build())
-                            .retrieve()
-                            .bodyToMono(String.class)
-                            .map(this::parseContainers)
-                            .map(containers -> new Elements(images, containers))
-                );
+        Mono<Elements.Container[]> containersMono = this.containerWebClient.build()
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .port(containerPort)
+                        .path("/containers/json")
+                        .queryParam("all", "true")
+                        .build())
+                .retrieve()
+                .bodyToMono(String.class)
+                .map(this::parseContainers);
+
+        return Mono.zip(imagesMono, containersMono, Elements::new);
     }
 
     // Todo: 아래 파싱 함수들 리팩토링 하기, 예외 처리

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
@@ -52,7 +52,7 @@ public class SandboxService {
         );
         return this.dockerWebClient.build()
                 .post()
-                .uri("/containers/create")
+                .uri(uriBuilder -> uriBuilder.path("/containers/create").build())
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(body)
                 .retrieve()
@@ -64,7 +64,7 @@ public class SandboxService {
         // Start Container
         return this.dockerWebClient.build()
                 .post()
-                .uri("/containers/" + containerId + "/start")
+                .uri(uriBuilder -> uriBuilder.path("/containers/{containerId}/start").build(containerId))
                 .contentType(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toBodilessEntity()
@@ -74,7 +74,7 @@ public class SandboxService {
     public Mono<String> getContainerPort(String containerId) {
         return this.dockerWebClient.build()
                 .get()
-                .uri("containers/" + containerId + "/json")
+                .uri(uriBuilder -> uriBuilder.path("containers/{containerId}/json").build(containerId))
                 .retrieve()
                 .bodyToMono(String.class)
                 .flatMap(data -> {
@@ -95,7 +95,7 @@ public class SandboxService {
     public Mono<Void> releaseUserSession(String containerId) {
         return this.dockerWebClient.build()
                 .delete()
-                .uri("containers/" + containerId + "?force=true&v=true")
+                .uri(uriBuilder -> uriBuilder.path("containers/{containerId}").queryParam("force", "true").queryParam("v", "true").build(containerId))
                 .retrieve()
                 .toBodilessEntity()
                 .then();

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
@@ -101,19 +101,15 @@ public class SandboxService {
                 .then();
     }
 
-    public String getHostStatus(int containerPort) {
-        // Todo: 상태 코드 예외 잡기
-        this.containerWebClient.build()
+    public Mono<String> getHostStatus(int containerPort) {
+        return this.containerWebClient.build()
                 .get()
                 .uri(uriBuilder -> uriBuilder.port(containerPort).path("/_ping").build())
                 .retrieve()
                 .onStatus(HttpStatus.INTERNAL_SERVER_ERROR::equals, clientResponse -> Mono.just(new Exception()))
                 .bodyToMono(String.class)
-                .onErrorResume(e -> {
-                    return Mono.just(STARTING);
-                }).block();
-
-        return READY;
+                .map(response -> READY)
+                .onErrorResume(e -> Mono.just(STARTING));
     }
 
     public Elements getUserContainersImages(int containerPort) {

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
@@ -92,13 +92,13 @@ public class SandboxService {
                 });
     }
 
-    public void releaseUserSession(String containerId) {
-        this.dockerWebClient.build()
+    public Mono<Void> releaseUserSession(String containerId) {
+        return this.dockerWebClient.build()
                 .delete()
                 .uri("containers/" + containerId + "?force=true&v=true")
                 .retrieve()
                 .toBodilessEntity()
-                .subscribe();
+                .then();
     }
 
     public String getHostStatus(int containerPort) {


### PR DESCRIPTION
# 작업 내용
- `SandboxService` 논블로킹 구현
- `SandboxController` 논블로킹 구현
- `Quiz` 가져오기 `Optional`문제 해결
- `ObjectMapper` 의존성 주입

## 세부 기록
### 1. Controller의 `Mono` or `Flux`
Spring Webflux에는 `Mono`와 `Flux`라는 Publisher가 존재한다. 논블로킹이 이루어지는 방식은 해당 Publisher에 데이터 변화가 감지되면, `subscribe`하고 있는 `Subscriber`가 원하는 동작을 진행한다. 이에 따라, Subscriber는 `subscribe`함수를 통해 원하는 콜백 함수를 전달할 수 있다.

하지만, `Controller`의 경우`Mono` or `Flux`와 같은 Publisher클래스를 return type으로 지정하면 자동으로 `subscribe`되어 `subscribe`메소드를 따로 호출할 필요가 없다.

### 2. 논블로킹과 블로킹
논블로킹과 블로킹은 서로 장단점이 상반된다.

논블로킹의 경우 I/O 작업의 응답을 기다리지 않고 다른 CPU 작업을 처리하기 때문에 CPU 사용률이 높다. 하지만, I/O 작업 이후의 동작을 미리 지정하는 선언형 프로그래밍 방식이므로 가독성이 떨어질 수 있다. 예를 들어, Spring WebFlux에서 flatMap이나 map을 사용하면 내부에 여러 메서드가 중첩되어 코드가 복잡해질 수 있다.

반면, 블로킹은 I/O 작업이 끝날 때까지 스레드가 대기한다. 이로 인해 I/O 작업이 길어질 경우 스레드가 점유되어 CPU 사용률이 낮아질 수 있지만, 코드가 논리적 프로그래밍 방식으로 직관적이며 가독성이 높다.

결과적으로, 논블로킹 방식이 CPU 사용률이 높다고 해서 항상 더 좋은 것은 아니다. 성능 측면에서는 논블로킹이 효율적이지만, 유지보수성을 고려하면 블로킹 방식이 더 나을 수도 있다. 따라서, I/O 작업 시간이 짧다면 블로킹 방식을 사용하여 유지보수성을 높이고, I/O 작업이 길거나 요청이 많은 경우에는 논블로킹을 사용하여 성능을 최적화하는 것이 좋다.


