### PR TITLE
SandboxService 테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,8 @@ dependencies {
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-}
+	testImplementation 'io.projectreactor:reactor-test:3.6.5'
+	}
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/src/main/java/com/LearnDocker/LearnDocker/Configuration/AppConfig.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/Configuration/AppConfig.java
@@ -1,9 +1,13 @@
 package com.LearnDocker.LearnDocker.Configuration;
 
+import com.LearnDocker.LearnDocker.CreateContainerBody;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import java.util.Map;
 
 @Configuration
 public class AppConfig {
@@ -20,5 +24,18 @@ public class AppConfig {
     @Bean
     public ObjectMapper objectMapper() {
         return new ObjectMapper();
+    }
+
+    @Bean
+    public CreateContainerBody containerInfo() {
+        return new CreateContainerBody(
+                "dind",
+                new CreateContainerBody.HostConfig(
+                        true,
+                        Map.of("2375/tcp", List.of(new CreateContainerBody.PortBinding("0", "0.0.0.0")))
+                ),
+                List.of("DOCKER_TLS_CERTDIR="),
+                List.of("--tls=false")
+        );
     }
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/DockerAPI.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/DockerAPI.java
@@ -1,0 +1,104 @@
+package com.LearnDocker.LearnDocker;
+
+import com.LearnDocker.LearnDocker.DTO.Elements;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+@Component
+public class DockerAPI {
+
+    private final WebClient.Builder dockerWebClient;
+    private final WebClient.Builder containerWebClient;
+    private final ObjectParser objectParser;
+    private static final String STARTING = "STARTING";
+    private static final String READY = "READY";
+
+    @Autowired
+    public DockerAPI(@Qualifier("DockerWebClient") WebClient dockerWebClient, @Qualifier("ContainerWebClient") WebClient containerWebClient, ObjectParser objectParser) {
+        this.dockerWebClient = dockerWebClient.mutate();
+        this.containerWebClient = containerWebClient.mutate();
+        this.objectParser = objectParser;
+    }
+
+    public Mono<String> createUserContainerAPI(CreateContainerBody body) {
+        return this.dockerWebClient.build()
+                .post()
+                .uri(uriBuilder -> uriBuilder.path("/containers/create").build())
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>(){})
+                .map(response -> (String) response.get("Id"));
+    }
+
+    public Mono<Void> startUserContainerAPI(String containerId) {
+        return this.dockerWebClient.build()
+                .post()
+                .uri(uriBuilder -> uriBuilder.path("/containers/{containerId}/start").build(containerId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .toBodilessEntity()
+                .then();
+    }
+
+    public Mono<String> getContainerPortAPI(String containerId) {
+        return this.dockerWebClient.build()
+                .get()
+                .uri(uriBuilder -> uriBuilder.path("containers/{containerId}/json").build(containerId))
+                .retrieve()
+                .bodyToMono(String.class)
+                .flatMap(this.objectParser::portResponseParse);
+    }
+
+    public Mono<Void> releaseUserSessionAPI(String containerId) {
+        return this.dockerWebClient.build()
+                .delete()
+                .uri(uriBuilder -> uriBuilder.path("containers/{containerId}").queryParam("force", "true").queryParam("v", "true").build(containerId))
+                .retrieve()
+                .toBodilessEntity()
+                .then();
+    }
+
+    public Mono<String> getHostStatusAPI(int containerPort) {
+        return this.containerWebClient.build()
+                .get()
+                .uri(uriBuilder -> uriBuilder.port(containerPort).path("/_ping").build())
+                .retrieve()
+                .onStatus(HttpStatus.INTERNAL_SERVER_ERROR::equals, clientResponse -> Mono.just(new Exception()))
+                .bodyToMono(String.class)
+                .map(response -> READY)
+                .onErrorResume(e -> Mono.just(STARTING));
+    }
+
+    public Mono<Elements.Image[]> getUserImagesAPI(int containerPort) {
+        return this.containerWebClient.build()
+                .get()
+                .uri(uriBuilder -> uriBuilder.port(containerPort).path("/images/json").build())
+                .retrieve()
+                .bodyToMono(String.class)
+                .map(this.objectParser::parseImages);
+    }
+
+    public Mono<Elements.Container[]> getContainersAPI(int containerPort) {
+        return this.containerWebClient.build()
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .port(containerPort)
+                        .path("/containers/json")
+                        .queryParam("all", "true")
+                        .build())
+                .retrieve()
+                .bodyToMono(String.class)
+                .map(this.objectParser::parseContainers);
+    }
+}

--- a/src/main/java/com/LearnDocker/LearnDocker/ObjectParser.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/ObjectParser.java
@@ -1,0 +1,66 @@
+package com.LearnDocker.LearnDocker;
+
+import com.LearnDocker.LearnDocker.DTO.Elements;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class ObjectParser {
+
+    private ObjectMapper objectMapper;
+
+    public ObjectParser(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public Mono<String> portResponseParse(String response) {
+        try {
+            JsonNode json = this.objectMapper.readTree(response);
+            String containerPort = json.get("NetworkSettings").get("Ports").get("2375/tcp").get(0).get("HostPort").asText();
+            return Mono.just(containerPort);
+        } catch (Exception e) {
+            System.out.println("JSON 참조 틀림");
+        }
+        return Mono.just("");
+    }
+
+    // Todo: 아래 파싱 함수들 리팩토링 하기, 예외 처리
+    public Elements.Image[] parseImages(String responseImages) {
+        try {
+            JsonNode rootArray = this.objectMapper.readTree(responseImages);
+            List<Elements.Image> imageList = new ArrayList<>();
+            for (JsonNode imageNode : rootArray) {
+                String id = imageNode.get("Id").asText();
+                String name = imageNode.get("RepoTags").get(0).asText().split(":")[0];
+                imageList.add(new Elements.Image(id, name));
+            }
+            return imageList.toArray(new Elements.Image[0]);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public Elements.Container[] parseContainers(String responseContainers) {
+        try {
+            JsonNode rootArray = this.objectMapper.readTree(responseContainers);
+            List<Elements.Container> containerList = new ArrayList<>();
+            for (JsonNode containerNode : rootArray) {
+                String id = containerNode.get("Id").asText();
+                String name = containerNode.get("Names").get(0).asText().split("/")[1];
+                String image = containerNode.get("Image").asText();
+                String status = containerNode.get("State").asText();
+                containerList.add(new Elements.Container(id, name, image, status));
+            }
+            return containerList.toArray(new Elements.Container[0]);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
@@ -2,30 +2,19 @@ package com.LearnDocker.LearnDocker;
 
 import com.LearnDocker.LearnDocker.DTO.ContainerInfo;
 import com.LearnDocker.LearnDocker.DTO.Elements;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 @Service
 public class SandboxService {
-    private static final String READY = "READY";
-    private static final String STARTING = "STARTING";
     private final DockerAPI dockerAPI;
+    private final CreateContainerBody newContainerBody;
 
     @Autowired
-    public SandboxService(DockerAPI dockerAPI) {
+    public SandboxService(DockerAPI dockerAPI, CreateContainerBody containerBody) {
         this.dockerAPI = dockerAPI;
+        this.newContainerBody = containerBody;
     }
 
     public Mono<ContainerInfo> assignUserContainer() {
@@ -39,20 +28,10 @@ public class SandboxService {
 
 
     public Mono<String> createUserContainer() {
-        CreateContainerBody body = new CreateContainerBody(
-                "dind",
-                new CreateContainerBody.HostConfig(
-                        true,
-                        Map.of("2375/tcp", List.of(new CreateContainerBody.PortBinding("0", "0.0.0.0")))
-                ),
-                List.of("DOCKER_TLS_CERTDIR="),
-                List.of("--tls=false")
-        );
-        return this.dockerAPI.createUserContainerAPI(body);
+        return this.dockerAPI.createUserContainerAPI(newContainerBody);
     }
 
     public Mono<Void> startUserContainer(String containerId) {
-        // Start Container
         return this.dockerAPI.startUserContainerAPI(containerId);
     }
 

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
@@ -21,15 +21,11 @@ import java.util.Map;
 public class SandboxService {
     private static final String READY = "READY";
     private static final String STARTING = "STARTING";
-    private final WebClient.Builder dockerWebClient;
-    private final WebClient.Builder containerWebClient;
-    private final ObjectMapper objectMapper;
+    private final DockerAPI dockerAPI;
 
     @Autowired
-    public SandboxService(@Qualifier("DockerWebClient") WebClient dockerWebClient, @Qualifier("ContainerWebClient") WebClient containerWebClient, ObjectMapper objectMapper) {
-        this.dockerWebClient = dockerWebClient.mutate();
-        this.containerWebClient = containerWebClient.mutate();
-        this.objectMapper = objectMapper;
+    public SandboxService(DockerAPI dockerAPI) {
+        this.dockerAPI = dockerAPI;
     }
 
     public Mono<ContainerInfo> assignUserContainer() {
@@ -52,123 +48,30 @@ public class SandboxService {
                 List.of("DOCKER_TLS_CERTDIR="),
                 List.of("--tls=false")
         );
-        return this.dockerWebClient.build()
-                .post()
-                .uri(uriBuilder -> uriBuilder.path("/containers/create").build())
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(body)
-                .retrieve()
-                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>(){})
-                .map(response -> (String) response.get("Id"));
+        return this.dockerAPI.createUserContainerAPI(body);
     }
 
     public Mono<Void> startUserContainer(String containerId) {
         // Start Container
-        return this.dockerWebClient.build()
-                .post()
-                .uri(uriBuilder -> uriBuilder.path("/containers/{containerId}/start").build(containerId))
-                .contentType(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .toBodilessEntity()
-                .then();
+        return this.dockerAPI.startUserContainerAPI(containerId);
     }
 
     public Mono<String> getContainerPort(String containerId) {
-        return this.dockerWebClient.build()
-                .get()
-                .uri(uriBuilder -> uriBuilder.path("containers/{containerId}/json").build(containerId))
-                .retrieve()
-                .bodyToMono(String.class)
-                .flatMap(data -> {
-                    String containerPort;
-                    try {
-                        JsonNode json = this.objectMapper.readTree(data);
-                        containerPort = json.get("NetworkSettings").get("Ports").get("2375/tcp").get(0).get("HostPort").asText();
-                        return Mono.just(containerPort);
-                    } catch (Exception e) {
-                        // Todo: 예외 잡기
-                        System.out.println("JSON 참조 틀림");
-                    }
-                    return Mono.just("");
-                });
+        return this.dockerAPI.getContainerPortAPI(containerId);
     }
 
     public Mono<Void> releaseUserSession(String containerId) {
-        return this.dockerWebClient.build()
-                .delete()
-                .uri(uriBuilder -> uriBuilder.path("containers/{containerId}").queryParam("force", "true").queryParam("v", "true").build(containerId))
-                .retrieve()
-                .toBodilessEntity()
-                .then();
+        return this.dockerAPI.releaseUserSessionAPI(containerId);
     }
 
     public Mono<String> getHostStatus(int containerPort) {
-        return this.containerWebClient.build()
-                .get()
-                .uri(uriBuilder -> uriBuilder.port(containerPort).path("/_ping").build())
-                .retrieve()
-                .onStatus(HttpStatus.INTERNAL_SERVER_ERROR::equals, clientResponse -> Mono.just(new Exception()))
-                .bodyToMono(String.class)
-                .map(response -> READY)
-                .onErrorResume(e -> Mono.just(STARTING));
+        return this.dockerAPI.getHostStatusAPI(containerPort);
     }
 
     public Mono<Elements> getUserContainersImages(int containerPort) {
-        Mono<Elements.Image[]> imagesMono = this.containerWebClient.build()
-                .get()
-                .uri(uriBuilder -> uriBuilder.port(containerPort).path("/images/json").build())
-                .retrieve()
-                .bodyToMono(String.class)
-                .map(this::parseImages);
-
-        Mono<Elements.Container[]> containersMono = this.containerWebClient.build()
-                .get()
-                .uri(uriBuilder -> uriBuilder
-                        .port(containerPort)
-                        .path("/containers/json")
-                        .queryParam("all", "true")
-                        .build())
-                .retrieve()
-                .bodyToMono(String.class)
-                .map(this::parseContainers);
+        Mono<Elements.Image[]> imagesMono = this.dockerAPI.getUserImagesAPI(containerPort);
+        Mono<Elements.Container[]> containersMono = this.dockerAPI.getContainersAPI(containerPort);
 
         return Mono.zip(imagesMono, containersMono, Elements::new);
     }
-
-    // Todo: 아래 파싱 함수들 리팩토링 하기, 예외 처리
-    public Elements.Image[] parseImages(String responseImages) {
-        try {
-            JsonNode rootArray = this.objectMapper.readTree(responseImages);
-            List<Elements.Image> imageList = new ArrayList<>();
-            for (JsonNode imageNode : rootArray) {
-                String id = imageNode.get("Id").asText();
-                String name = imageNode.get("RepoTags").get(0).asText().split(":")[0];
-                imageList.add(new Elements.Image(id, name));
-            }
-            return imageList.toArray(new Elements.Image[0]);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return null;
-    }
-    
-    public Elements.Container[] parseContainers(String responseContainers) {
-        try {
-            JsonNode rootArray = this.objectMapper.readTree(responseContainers);
-            List<Elements.Container> containerList = new ArrayList<>();
-            for (JsonNode containerNode : rootArray) {
-                String id = containerNode.get("Id").asText();
-                String name = containerNode.get("Names").get(0).asText().split("/")[1];
-                String image = containerNode.get("Image").asText();
-                String status = containerNode.get("State").asText();
-                containerList.add(new Elements.Container(id, name, image, status));
-            }
-            return containerList.toArray(new Elements.Container[0]);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return null;
-    }
-
-
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
@@ -18,25 +18,12 @@ public class SandboxService {
     }
 
     public Mono<ContainerInfo> assignUserContainer() {
-        return createUserContainer()
+        return this.dockerAPI.createUserContainerAPI(newContainerBody)
                 .flatMap(containerId ->
-                        startUserContainer(containerId)
-                                .then(getContainerPort(containerId)
+                        this.dockerAPI.startUserContainerAPI(containerId)
+                                .then(this.dockerAPI.getContainerPortAPI(containerId)
                                         .map(containerPort -> new ContainerInfo(containerId, containerPort)))
                 );
-    }
-
-
-    public Mono<String> createUserContainer() {
-        return this.dockerAPI.createUserContainerAPI(newContainerBody);
-    }
-
-    public Mono<Void> startUserContainer(String containerId) {
-        return this.dockerAPI.startUserContainerAPI(containerId);
-    }
-
-    public Mono<String> getContainerPort(String containerId) {
-        return this.dockerAPI.getContainerPortAPI(containerId);
     }
 
     public Mono<Void> releaseUserSession(String containerId) {

--- a/src/test/java/com/LearnDocker/LearnDocker/SandboxServiceTests.java
+++ b/src/test/java/com/LearnDocker/LearnDocker/SandboxServiceTests.java
@@ -1,19 +1,89 @@
 package com.LearnDocker.LearnDocker;
 
+import com.LearnDocker.LearnDocker.DTO.ContainerInfo;
+import com.LearnDocker.LearnDocker.DTO.Elements;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 public class SandboxServiceTests {
-    private final SandboxService sandboxService;
-    public SandboxServiceTests(SandboxService sandboxService) {
-        this.sandboxService = sandboxService;
-    }
+
+    @MockitoBean
+    private DockerAPI dockerAPI;
+
+    @Autowired
+    private SandboxService sandboxService;
+
+    private static final String TEST_ELEMENTS_ID = "55e48d950fc04bd9b92587253698668e759f794c7a8046ebb66eb860519fe321";
+    private static final String TEST_CONTAINER_PORT = "8000";
+    private static final String TEST_IMAGE_NAME = "TEST";
+    
     @Test
-    public void createUserContainer() {
-        Mono<String> response = this.sandboxService.createUserContainer();
+    @DisplayName("사용자 container 및 할당 테스트")
+    public void assignUserContainerTest() {
+        // Given
+        when(dockerAPI.createUserContainerAPI(any())).thenReturn(
+                Mono.just(TEST_ELEMENTS_ID)
+        );
 
+        when(dockerAPI.startUserContainerAPI(TEST_ELEMENTS_ID)).thenReturn(
+                Mono.empty()
+        );
 
+        when(dockerAPI.getContainerPortAPI(TEST_ELEMENTS_ID)).thenReturn(
+                Mono.just(TEST_CONTAINER_PORT)
+        );
+
+        // When
+        Mono<ContainerInfo> result = this.sandboxService.assignUserContainer();
+
+        // Then
+        StepVerifier.create(result)
+                .expectNextMatches(response ->
+                        response.getContainerId().equals(TEST_ELEMENTS_ID) &&
+                        response.getContainerPort().equals(TEST_CONTAINER_PORT)
+                )
+                .expectComplete()
+                .verify();
     }
+
+    @Test
+    @DisplayName("사용자의 Docker환경에서 Elements를 불러오기 테스트")
+    public void getUserContainersImagesTest() {
+        // Given
+        when(dockerAPI.getUserImagesAPI(Integer.parseInt(TEST_CONTAINER_PORT))).thenReturn(
+                Mono.just(new Elements.Image[]{new Elements.Image(
+                      TEST_ELEMENTS_ID,
+                      TEST_IMAGE_NAME
+              )})
+        );
+
+        when(dockerAPI.getContainersAPI(Integer.parseInt(TEST_CONTAINER_PORT))).thenReturn(
+            Mono.just(new Elements.Container[]{})
+        );
+
+        Mono<Elements> result = sandboxService.getUserContainersImages(Integer.parseInt(TEST_CONTAINER_PORT));
+
+        // Then
+        StepVerifier.create(result)
+                .expectNextMatches(response -> {
+                    Elements.Image image = response.getImages()[0];
+                    Elements.Container[] containers = response.getContainers();
+                    return (
+                        image.getId().equals(TEST_ELEMENTS_ID) &&
+                        image.getName().equals(TEST_IMAGE_NAME) &&
+                        containers.length == 0
+                    );
+                }).expectComplete()
+                .verify();
+    }
+
 }


### PR DESCRIPTION
# 작업 내용
- `SandboxService`의 역할 분담
- `ObjectParser`클래스 구현
- `DockerAPI`클래스 구현
- `SandboxService`클래스 테스트 코드 작성

## 세부 기록
### 1. `Session`과 관련한 테스트 코드
`SandboxController`를 테스트 하기 위한 코드를 작성했지만, `WebTestClient`클래스의 인스턴스에 `HttpSession`이 적용되지 않는 관계로 `500`에러가 발생해 테스트가 불가능했다.

Session을 활용하기 위해서 `@WebFluxTest`가 아닌 `@WebMvcTest`로 해보아도, Controller에서는 `Mono`를 반환하기 때문에 올바른 Body값을 받아올 수 없었다. 이를 해결하기 위해서는 `WebFlux`에 사용되는 Session관리를 위한 `WebSession`을 활용해야 할 것 같다. 나중에 개선해야할 것 같다.

### 2. 테스트 코드 작성 시 해당 클래스와 메소드의 역할을 생각해보자.
테스트 코드를 작성할 때 해당 클래스의 역할을 우선적으로 생각해보아야 한다. Controller클래스의 메소드를 테스트한다고 가정하면, Controller클래스의 메소드는 사용자의 Request를 받아들이고 처리한 후 Response를 반환하는 역할을 한다. 즉, 테스트 코드에서는 사용자의 어떠한 요청이 주어졌을 때 어떤 응답을 받는 지에 대한 테스트를 진행해야 한다. 

> [!Notice]
> 하지만, 여기서 만약 실제 Controller에 요청을 보내는 테스트를 진행하게 되면 이는 > 통합 테스트로 변하게 된다.

또한, 만약 하나의 메소드에 대해 테스트 코드를 작성한다면, 해당 메소드에서 단순히 외부 API요청에 대한 응답만 반환하는 메소드라면 굳이 테스트 코드를 작성할 필요가 있을까? 당연히 아니다, 메소드를 테스트 하는 이유는, 외부 종속성을 테스트 하는 것이 아니고, 메소드 자체의 로직이 잘 작동하는가? 를 검증하는 것이다. 따라서, 이런 경우는 굳이 테스트 코드를 작성할 필요는 없다.

### 3. `@MockBean`에 대해
`@MockBean`은 Spring 4.5.0버전에 deprecated되었다. 따라서, 이에 대한 대안으로 `@MockitoBean`을 활용하면 된다.

## 추후 해야할 것
- 예외 처리
- 예외 처리에 따른 테스트 코드 작성(테케 늘리기 - 테스트 커버리지 늘리기)
