### PR TITLE
사용자 명령 입력 기능 구현

### DIFF
--- a/src/main/java/com/LearnDocker/LearnDocker/CommandValidator.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/CommandValidator.java
@@ -1,0 +1,27 @@
+package com.LearnDocker.LearnDocker;
+
+import java.util.regex.Pattern;
+
+public class CommandValidator {
+    private static final Pattern VALID_REGEX = Pattern.compile("^docker\s(?:(?!.*\b(?:sh|bash|exec|tag|commit)\b|.*[;&|<>$`]))");
+    private static final Pattern VOLUME_MOUNT_CHECK_REGEX =
+                Pattern.compile("^docker\s+(?:(?:container\s+)?(?:create|run))\s+.*(?:-v\b|--volume\b)");
+    private static final Pattern PUSH_CHECK_REGEX = Pattern.compile("^docker\s+(?:(?:image\s+)?(?:push))");
+    private static final Pattern DOCKER_RUN_CHECK_REGEX = Pattern.compile("^docker\s+(?:(?:container\s+)?(?:run))");
+    private static final Pattern DETACH_OPTION_REGEX = Pattern.compile("(?:-d\b|--detach\b)");
+    private static final Pattern JOKE_IMAGE_NAME = Pattern.compile("learndocker.io/joke");
+
+    public static String getValidCommand(String command) throws Exception {
+        command = command.trim();
+
+        boolean baseValidation = VALID_REGEX.matcher(command).find();
+        boolean volumeMountValidation = VOLUME_MOUNT_CHECK_REGEX.matcher(command).matches();
+        boolean pushValidation = PUSH_CHECK_REGEX.matcher(command).find();
+        boolean isValid = baseValidation && !volumeMountValidation && !pushValidation;
+        if (!isValid) {
+            throw new Exception("해당 명령은 사용이 불가능합니다.");
+        }
+
+        return command;
+    }
+}

--- a/src/main/java/com/LearnDocker/LearnDocker/Configuration/AppConfig.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/Configuration/AppConfig.java
@@ -13,12 +13,16 @@ import java.util.Map;
 public class AppConfig {
     @Bean(name="DockerWebClient")
     public WebClient getWebClient() {
-        return WebClient.create("http://localhost:2375");
+        return WebClient.builder()
+                .baseUrl("http://localhost:2375")
+                .build();
     }
 
     @Bean(name="ContainerWebClient")
     public WebClient getContainerWebClient() {
-        return WebClient.create("http://localhost");
+        return WebClient.builder()
+                .baseUrl("http://localhost")
+                .build();
     }
 
     @Bean

--- a/src/main/java/com/LearnDocker/LearnDocker/DTO/Command.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/DTO/Command.java
@@ -1,0 +1,12 @@
+package com.LearnDocker.LearnDocker.DTO;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class Command {
+    private String command;
+
+    public Command() {}
+}

--- a/src/main/java/com/LearnDocker/LearnDocker/DTO/ExecCreate.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/DTO/ExecCreate.java
@@ -1,0 +1,22 @@
+package com.LearnDocker.LearnDocker.DTO;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ExecCreate {
+    private final boolean AttachStdin;
+    private final boolean AttachStdout;
+    private final boolean AttachStderr;
+    private boolean Tty;
+    private String[] Cmd;
+
+    public ExecCreate(boolean AttachStdin, boolean AttachStdout, boolean AttachStderr, boolean Tty, String[] Cmd) {
+        this.AttachStdin = AttachStdin;
+        this.AttachStdout = AttachStdout;
+        this.AttachStderr = AttachStderr;
+        this.Tty = Tty;
+        this.Cmd = Cmd;
+    }
+}

--- a/src/main/java/com/LearnDocker/LearnDocker/DTO/ExecStart.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/DTO/ExecStart.java
@@ -1,0 +1,14 @@
+package com.LearnDocker.LearnDocker.DTO;
+
+import lombok.Getter;
+
+public class ExecStart {
+    @Getter
+    private boolean Detach;
+    @Getter
+    private boolean Tty;
+    public ExecStart(boolean Detach, boolean Tty) {
+        this.Detach = Detach;
+        this.Tty = Tty;
+    }
+}

--- a/src/main/java/com/LearnDocker/LearnDocker/ObjectParser.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/ObjectParser.java
@@ -63,4 +63,14 @@ public class ObjectParser {
         }
         return null;
     }
+
+    public String parseCreationExecResponseBody(String creationExecResponseBody) {
+        try {
+            JsonNode json = this.objectMapper.readTree(creationExecResponseBody);
+            return json.get("Id").asText();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxController.java
@@ -1,6 +1,6 @@
 package com.LearnDocker.LearnDocker;
 
-import com.LearnDocker.LearnDocker.DTO.ContainerInfo;
+import com.LearnDocker.LearnDocker.DTO.Command;
 import com.LearnDocker.LearnDocker.DTO.Elements;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -64,6 +64,21 @@ public class SandboxController {
                     .map(Integer::parseInt)
                     .flatMap(this.sandboxService::getUserContainersImages)
                     .map(ResponseEntity::ok);
+    }
+
+    @PostMapping("command")
+    public Mono<ResponseEntity<String>> processUserCommand(HttpServletRequest httpServletRequest, @RequestBody Command body) {
+        try {
+            String command = CommandValidator.getValidCommand(body.getCommand());
+            String containerId = Objects.toString(httpServletRequest.getSession().getAttribute("containerId"));
+            return sandboxService.processUserCommand(command, containerId)
+                    .map(ResponseEntity::ok);
+        } catch (Exception e) {
+            // 예외처리
+            System.out.println();
+        }
+        // TODO: 예외 처리
+        return null;
     }
 
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
@@ -6,6 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
+import java.util.Arrays;
+
 @Service
 public class SandboxService {
     private final DockerAPI dockerAPI;
@@ -39,5 +41,9 @@ public class SandboxService {
         Mono<Elements.Container[]> containersMono = this.dockerAPI.getContainersAPI(containerPort);
 
         return Mono.zip(imagesMono, containersMono, Elements::new);
+    }
+
+    public Mono<String> processUserCommand(String command, String containerId) {
+        return this.dockerAPI.requestDockerCommand(containerId, command.split(" "));
     }
 }


### PR DESCRIPTION
# 작업 내용
- `WebClient`객체 build 후 의존성 주입하도록 변경(Builder패턴)
- Command controller, service, Docker API구현
- NestJS의 Pipe와 유사한 동작을 하는 Validator 구현
- `Command`, `ExecCreate`, `ExecStart` DTO객체 구현

## 세부 기록
### 1. WebClient의 pathParam

WebClient의 PathParameter를 정의할 때 `build()`메소드의 매개변수에 데이터를 전달해야 pathParam에 데이터가 잘 전달된다.. 이것 때문에 몇시간 날린듯.. Docker API에서 응답 받은 후 처리를 안해서 계속 원인을 못찾았다.. 개발 중에도 외부 API의 응답에 따른 예외 처리를 좀 잘 해야겠다.

```java
.uri(uriBuilder -> uriBuilder.path("/containers/{containerId}/exec").build(containerId))
```

위와 같은 식으로 해야 `/containers/~~~/exec`경로로 올바르게 설정된다.

### 2. DTO(Data Transfer Object)와 VO(Value Object)

DTO (Data Transfer Object) 는 계층 간 데이터를 전달할 때 사용되며, 가변성을 가지므로 Getter와 Setter를 포함할 수 있다.

반면, VO (Value Object) 는 특정 값을 표현하는 불변 객체로, Getter만 가질 수 있으며, 한 번 생성되면 변경할 수 없다.

> [!Tip]
> 불변성을 유지하면 좋은 점
> 데이터가 예상치 못하게 변경될 위험이 줄어들어 프로그램의 안정성이 높아진다.
