### PR TITLE
Sandbox Test코드 작성 및 로컬 레지스트리 접속을 위한 설정

### DIFF
--- a/src/main/java/com/LearnDocker/LearnDocker/CommandValidator.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/CommandValidator.java
@@ -3,9 +3,9 @@ package com.LearnDocker.LearnDocker;
 import java.util.regex.Pattern;
 
 public class CommandValidator {
-    private static final Pattern VALID_REGEX = Pattern.compile("^docker\s(?:(?!.*\b(?:sh|bash|exec|tag|commit)\b|.*[;&|<>$`]))");
-    private static final Pattern VOLUME_MOUNT_CHECK_REGEX =
-                Pattern.compile("^docker\s+(?:(?:container\s+)?(?:create|run))\s+.*(?:-v\b|--volume\b)");
+    private static final Pattern VALID_REGEX = Pattern.compile("^docker\\s(?:(?!.*(?:sh|bash|exec|tag|commit)\\b|.*[;&|<>$`]).)+$");
+    private static final Pattern OPTION_CHECK_REGEX =
+                Pattern.compile("^docker\s+(?:(?:container\s+)?(?:create|run))\s+.*(?:-v\s|--volume\s|-p\s)");
     private static final Pattern PUSH_CHECK_REGEX = Pattern.compile("^docker\s+(?:(?:image\s+)?(?:push))");
     private static final Pattern DOCKER_RUN_CHECK_REGEX = Pattern.compile("^docker\s+(?:(?:container\s+)?(?:run))");
     private static final Pattern DETACH_OPTION_REGEX = Pattern.compile("(?:-d\b|--detach\b)");
@@ -15,7 +15,7 @@ public class CommandValidator {
         command = command.trim();
 
         boolean baseValidation = VALID_REGEX.matcher(command).find();
-        boolean volumeMountValidation = VOLUME_MOUNT_CHECK_REGEX.matcher(command).matches();
+        boolean volumeMountValidation = OPTION_CHECK_REGEX.matcher(command).find();
         boolean pushValidation = PUSH_CHECK_REGEX.matcher(command).find();
         boolean isValid = baseValidation && !volumeMountValidation && !pushValidation;
         if (!isValid) {

--- a/src/main/java/com/LearnDocker/LearnDocker/Configuration/AppConfig.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/Configuration/AppConfig.java
@@ -37,6 +37,7 @@ public class AppConfig {
                 new CreateContainerBody.HostConfig(
                         true,
                         Map.of("2375/tcp", List.of(new CreateContainerBody.PortBinding("0", "0.0.0.0")))
+                        , List.of("learndocker.io:172.17.0.1")
                 ),
                 List.of("DOCKER_TLS_CERTDIR="),
                 List.of("--tls=false")

--- a/src/main/java/com/LearnDocker/LearnDocker/Configuration/SessionConfig.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/Configuration/SessionConfig.java
@@ -1,6 +1,7 @@
 package com.LearnDocker.LearnDocker.Configuration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -8,28 +9,25 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
-@Configuration(proxyBeanMethods = false)
+@Configuration
 @EnableRedisHttpSession(maxInactiveIntervalInSeconds = 14400)
 public class SessionConfig implements BeanClassLoaderAware {
 
     private ClassLoader loader;
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
 
     @Bean
     public LettuceConnectionFactory connectionFactory() {
-        return new LettuceConnectionFactory();
+        return new LettuceConnectionFactory(redisHost, redisPort);
     }
 
     @Bean
     public RedisSerializer<Object> springSessionDefaultRedisSerializer(ObjectMapper objectMapper) {
         return new GenericJackson2JsonRedisSerializer(objectMapper);
     }
-
-    // Sprint Security를 활용한 Jackson을 사용할 때 이용 할 Objecct Mapper
-//    private ObjectMapper objectMapper() {
-//        ObjectMapper objectMapper = new ObjectMapper();
-//        objectMapper.registerModules(SecurityJackson2Modules.getModules(this.loader));
-//        return objectMapper;
-//    }
 
     @Override
     public void setBeanClassLoader(ClassLoader classLoader) {

--- a/src/main/java/com/LearnDocker/LearnDocker/CreateContainerBody.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/CreateContainerBody.java
@@ -3,7 +3,7 @@ package com.LearnDocker.LearnDocker;
 import java.util.*;
 
 public record CreateContainerBody(String Image, HostConfig HostConfig, List<String> Env, List<String> Cmd) {
-    public record HostConfig(boolean Privileged, Map<String, List<PortBinding>> PortBindings) {
+    public record HostConfig(boolean Privileged, Map<String, List<PortBinding>> PortBindings, List<String> ExtraHosts) {
 
     }
 

--- a/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/SandboxService.java
@@ -6,8 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
-import java.util.Arrays;
-
 @Service
 public class SandboxService {
     private final DockerAPI dockerAPI;

--- a/src/test/java/com/LearnDocker/LearnDocker/CommandValidatorTest.java
+++ b/src/test/java/com/LearnDocker/LearnDocker/CommandValidatorTest.java
@@ -1,0 +1,63 @@
+package com.LearnDocker.LearnDocker;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+class CommandValidatorTest {
+    @ParameterizedTest
+    @DisplayName("Invalid Command 유효성 검증 테스트")
+    @MethodSource("invalidCommandProvider")
+    public void userCommandInvalidationTest(String command) {
+        CommandValidator validator = new CommandValidator();
+
+        Assertions.assertThatThrownBy(() -> validator.getValidCommand(command))
+                .isInstanceOf(Exception.class);
+    }
+
+    @ParameterizedTest
+    @DisplayName("Valid Command 유효성 검증 테스트")
+    @MethodSource("validCommandProvider")
+    public void userCommandValidationTest(String command) {
+        CommandValidator validator = new CommandValidator();
+
+        try {
+            String result = validator.getValidCommand(command);
+            Assertions.assertThat(result)
+                    .isEqualTo(command);
+        } catch (Exception e) {
+            Assertions.fail("예외가 발생하면 안됩니다.");
+        }
+    }
+
+    public static Stream<Arguments> invalidCommandProvider() {
+        return Stream.of(
+                // Option Check
+                Arguments.of("docker run -v /:/host ubuntu cat /host/etc/passwd"),
+                Arguments.of("docker run --volume /:/host ubuntu cat /host/etc/passwd"),
+                Arguments.of("docker container create -v /:/host ubuntu cat /host/etc/passwd"),
+                Arguments.of("docker run -p 8080:80"),
+                // Shell command
+                Arguments.of("sh -c docker ps; docker images"),
+                Arguments.of("docker ps | grep my_container"),
+                // push, exec
+                Arguments.of("docker push hello-world"),
+                Arguments.of("docker exec -it ubuntu")
+        );
+    }
+
+    public static Stream<Arguments> validCommandProvider() {
+        return Stream.of(
+                Arguments.of("docker run hello-world"),
+                Arguments.of("docker start hello-world"),
+                Arguments.of("docker ps"),
+                Arguments.of("docker images"),
+                Arguments.of("docker create hello-world"),
+                Arguments.of("docker stop hello-world")
+        );
+    }
+}


### PR DESCRIPTION
# 작업 내용
- Sandbox Test코드 작성(Command유효성 검사)
- 로컬 레지스트리 접속을 위한 Request Body변경
- Redis데이터 `@Value`애너테이션을 활용해 가져오기

## 세부 기록
### 1. Local Registry에 대한 구조
Local Registry의 경우 Docker를 통해 접속할 수 있는 Docker Registry중 하나이다. 즉, Dind컨테이너를 활용하는 사용자의 입장에서 Dind컨테이너에 Docker명령을 입력하면 자동으로 Docker Registry로 요청이 가야한다.

이를 위해 애초에 Dind컨테이너를 create하기 위한 요청의 Body에 기본 Docker Registry를 설정하면 된다.
``` java
const requestBody = {
          Image: 'dind',
          HostConfig: {
              Privileged: true,
              PortBindings: {
                  '2375/tcp': [
                      {
                          HostPort: '0',
                          HostIp: '0.0.0.0',
                      },
                  ],
              },
              ExtraHosts: ['learndocker.io:172.17.0.1'], // 172.17.0.1 IP주소를 활용해
          },
          Env: ['DOCKER_TLS_CERTDIR='],
          Cmd: ['--tls=false'],
      };
```
`ExtraHosts` config를 learndocker.io주소와 `172.17.0.1`주소를 매핑한 것이다. 해당 주소는 호스트 도커와 컨테이너 사이의 브릿지 주소로, 호스트 도커에 접속하기 위해 내부적으로 사용되는 IP주소로 활용된다.

따라서, 기본적으로 `172.17.0.1` IP주소 그리고 `80`포트를 Docker Registry의 주소로 설정하고, `docker run` , `docker pull` 등의 docker명령을 실행하면 해당 주소로 요청되어 명령이 처리된다.

### 2. `@Value`에너테이션에 대하여
Spring에서 `@Value`애너테이션은 `application.properties`파일에 설정된 value를 지정해 변수에 주입할 수 있다.

ex)

`application.properties`
```
spring.server.ip=127.0.0.1
```

위와 같은 설정 파일이 존재할 때

``` java
@Value("${spring.server.ip}")
private String serverIp;
```

위와 같이 `@Value`애너테이션을 활용하면 설정 파일의 값이 자동으로 주입된다. 이는 Node에서 활용하는 `dotenv`와 동일한 효과를 볼 수 있다.

> [!Tip]
> Docker에서의 `172.17.0.1` IP주소
>
> Docker에서는 기본적으로 호스트 Docker에 `172.17.0.1`이라는 가상 IP주소를 할당한다. 따라서, 내부 컨테이너에서 호스트 도커에 접속 시 해당 IP를 활용해 접속이 가능하다.
