### PR TITLE
채점 및 다음 문제로 이동 로직 구현

### DIFF
--- a/src/main/java/com/LearnDocker/LearnDocker/Configuration/WebConfig.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/Configuration/WebConfig.java
@@ -1,0 +1,31 @@
+package com.LearnDocker.LearnDocker.Configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+@Configuration
+public class WebConfig {
+
+    @Value("classpath:/static/index.html")
+    private Resource indexHtml;
+
+    @Bean
+    public RouterFunction<ServerResponse> staticRouter() {
+        return RouterFunctions
+                .resources("/**", new ClassPathResource("static/"))
+                .and(RouterFunctions.route(
+                        req -> req.method() == HttpMethod.GET && !req.path().startsWith("/api"),
+                        request -> ServerResponse.ok()
+                                .contentType(MediaType.TEXT_HTML)
+                                .bodyValue(indexHtml)
+                ));
+    }
+}

--- a/src/main/java/com/LearnDocker/LearnDocker/Controller/QuizController.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/Controller/QuizController.java
@@ -1,16 +1,15 @@
 package com.LearnDocker.LearnDocker.Controller;
 
 import com.LearnDocker.LearnDocker.DTO.Quiz;
+import com.LearnDocker.LearnDocker.Exception.BadQuizIdException;
 import com.LearnDocker.LearnDocker.Service.QuizService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 import java.util.Objects;
+import java.util.Optional;
 
 @RestController
 @RequestMapping(value="api/quiz")
@@ -35,4 +34,20 @@ public class QuizController {
                     return Mono.fromRunnable(() -> this.quizService.accessQuiz(quizId, level));
                 });
     }
+
+    @GetMapping("/{quizId}/submit")
+    public Mono<String> gradeQuiz(@PathVariable("quizId") int quizId, @RequestParam(value="userAnswer", required=false) String userAnswer, ServerWebExchange request) {
+        return request.getSession()
+                .flatMap(session -> {
+                    int containerPort = Integer.parseInt(Objects.requireNonNull(Objects.toString(session.getAttribute("containerPort"))));
+                    try {
+                        return this.quizService.grade(quizId, containerPort, userAnswer);
+                    } catch (BadQuizIdException e) {
+                        // Todo: 예외 처리
+                        e.printStackTrace();
+                    }
+                    return Mono.empty();
+                });
+    }
+
 }

--- a/src/main/java/com/LearnDocker/LearnDocker/Exception/BadQuizIdException.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/Exception/BadQuizIdException.java
@@ -1,0 +1,5 @@
+package com.LearnDocker.LearnDocker.Exception;
+
+public class BadQuizIdException extends Exception{
+    private String message = "해당 퀴즈 번호는 제공되지 않습니다.";
+}

--- a/src/main/java/com/LearnDocker/LearnDocker/ObjectParser.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/ObjectParser.java
@@ -53,9 +53,9 @@ public class ObjectParser {
             for (JsonNode containerNode : rootArray) {
                 String id = containerNode.get("Id").asText();
                 String name = containerNode.get("Names").get(0).asText().split("/")[1];
-                String image = containerNode.get("Image").asText();
                 String status = containerNode.get("State").asText();
-                containerList.add(new Elements.Container(id, name, image, status));
+                String image = containerNode.get("Image").asText();
+                containerList.add(new Elements.Container(id, name, status, image));
             }
             return containerList.toArray(new Elements.Container[0]);
         } catch (Exception e) {

--- a/src/main/java/com/LearnDocker/LearnDocker/Service/QuizService.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/Service/QuizService.java
@@ -2,6 +2,7 @@ package com.LearnDocker.LearnDocker.Service;
 
 import com.LearnDocker.LearnDocker.DTO.Quiz;
 import com.LearnDocker.LearnDocker.DockerAPI;
+import com.LearnDocker.LearnDocker.Exception.BadQuizIdException;
 import com.LearnDocker.LearnDocker.Repository.QuizRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -34,6 +35,31 @@ public class QuizService {
         }
     }
 
+    public Mono<String> grade(int quizId, int containerPort, String userAnswer) throws BadQuizIdException {
+        switch (quizId) {
+            case 1:
+                return gradeQuiz1(containerPort);
+            case 2:
+                return gradeQuiz2(containerPort, userAnswer);
+            case 3:
+                return gradeQuiz3(containerPort);
+            case 4:
+                return gradeQuiz4(containerPort);
+            case 5:
+                return gradeQuiz5(userAnswer);
+            case 6:
+                return gradeQuiz6(containerPort);
+            case 7:
+                return gradeQuiz7(userAnswer);
+            case 8:
+                return gradeQuiz8(containerPort, userAnswer);
+            case 9:
+                return gradeQuiz9(containerPort);
+            case 10:
+                return gradeQuiz10(containerPort);
+        }
+        throw new BadQuizIdException();
+    }
 
     public Mono<String> gradeQuiz1(int containerPort) {
         return this.dockerAPI.getUserImagesAPI(containerPort)
@@ -77,9 +103,11 @@ public class QuizService {
         String answerContainerName = "learndocker.io/hello-world";
         return this.dockerAPI.getContainersAPI(containerPort)
                 .flatMapMany(Flux::fromArray)
-                .filter(container ->
-                    (container.getImage() == answerContainerName)
-                ).next()
+                .filter(container ->{
+                    System.out.println("RRRR" + container.getImage());
+                    return container.getImage().equals(answerContainerName);
+                })
+                .next()
                 .map(container -> SUCCESS)
                 .switchIfEmpty(Mono.just(FAIL));
     }

--- a/src/main/java/com/LearnDocker/LearnDocker/Service/QuizService.java
+++ b/src/main/java/com/LearnDocker/LearnDocker/Service/QuizService.java
@@ -34,7 +34,8 @@ public class QuizService {
         }
     }
 
-    public Mono<String> gradeQuiz1(String sessionId, int containerPort, int level) {
+
+    public Mono<String> gradeQuiz1(int containerPort) {
         return this.dockerAPI.getUserImagesAPI(containerPort)
                 .flatMapMany(Flux::fromArray)
                 .filter(image ->  image.getName().contains("learndocker.io/hello-world"))
@@ -43,7 +44,7 @@ public class QuizService {
                 .switchIfEmpty(Mono.just(FAIL));
     }
 
-    public Mono<String> gradeQuiz2(String sessionId, int containerPort, String userAnswer, int level) {
+    public Mono<String> gradeQuiz2(int containerPort, String userAnswer) {
         return this.dockerAPI.getUserImagesAPI(containerPort)
                 .flatMapMany(Flux::fromArray)
                 .filter(image -> {
@@ -60,7 +61,7 @@ public class QuizService {
                 .switchIfEmpty(Mono.just(FAIL));
     }
 
-    public Mono<String> gradeQuiz3(String sessionId, int containerPort, int level) {
+    public Mono<String> gradeQuiz3(int containerPort) {
         return this.dockerAPI.getUserImagesAPI(containerPort)
                 .flatMapMany(Flux::fromArray)
                 .filter(image -> {
@@ -72,7 +73,7 @@ public class QuizService {
                 .switchIfEmpty(Mono.just(SUCCESS));
     }
 
-    public Mono<String> gradeQuiz4(String sessionId, int containerPort, int level) {
+    public Mono<String> gradeQuiz4(int containerPort) {
         String answerContainerName = "learndocker.io/hello-world";
         return this.dockerAPI.getContainersAPI(containerPort)
                 .flatMapMany(Flux::fromArray)
@@ -83,13 +84,13 @@ public class QuizService {
                 .switchIfEmpty(Mono.just(FAIL));
     }
 
-    public Mono<String> gradeQuiz5(String sessionId, String userAnswer, int level) {
+    public Mono<String> gradeQuiz5(String userAnswer) {
         String answer = "부스트캠프 웹모바일 9기 화이팅!";
 
         return (answer.equals(userAnswer)) ? Mono.just(SUCCESS) : Mono.just(FAIL);
     }
 
-    public Mono<String> gradeQuiz6(String sessionId, int containerPort, int level) {
+    public Mono<String> gradeQuiz6(int containerPort) {
         String containerName = "learndocker.io/joke";
         String containerStatus = "running";
 
@@ -101,13 +102,13 @@ public class QuizService {
                 .switchIfEmpty(Mono.just(FAIL));
     }
 
-    public Mono<String> gradeQuiz7(String sessionId, String userAnswer, int level) {
+    public Mono<String> gradeQuiz7(String userAnswer) {
         String answer = "스페이스바";
 
         return (userAnswer.equals(answer)) ? Mono.just(SUCCESS) : Mono.just(FAIL);
     }
 
-    public Mono<String> gradeQuiz8(String sessionId, int containerPort, String userAnswer, int level) {
+    public Mono<String> gradeQuiz8(int containerPort, String userAnswer) {
         return this.dockerAPI.getContainersAPI(containerPort)
                 .flatMapMany(Flux::fromArray)
                 .filter(container -> {
@@ -118,7 +119,7 @@ public class QuizService {
                 .switchIfEmpty(Mono.just(FAIL));
     }
 
-    public Mono<String> gradeQuiz9(String sessionId, int containerPort, int level) {
+    public Mono<String> gradeQuiz9(int containerPort) {
         String answerContainerName = "learndocker.io/joke";
         String answerStatus = "exited";
 
@@ -132,7 +133,7 @@ public class QuizService {
                 .switchIfEmpty(Mono.just(FAIL));
     }
 
-    public Mono<String> gradeQuiz10(String sessionId, int containerPort, int level) {
+    public Mono<String> gradeQuiz10(int containerPort) {
         return this.dockerAPI.getContainersAPI(containerPort)
                 .filter(containers -> (containers.length > 0) ? false : true)
                 .map(containers -> SUCCESS)

--- a/src/test/java/com/LearnDocker/LearnDocker/Service/QuizServiceTest.java
+++ b/src/test/java/com/LearnDocker/LearnDocker/Service/QuizServiceTest.java
@@ -24,12 +24,10 @@ class QuizServiceTest {
     private DockerAPI dockerAPI;
 
     private static final int TEST_CONTAINER_PORT = 8000;
-    private static final String SESSION_ID = "NTVjNjEyNjMtMDFmZi00ZjFkLTk4ZjItMWRlNmJmZmQwZWYx";
 
     @Test
     @DisplayName("이미지 가져오기 채점 테스트")
     public void GradeQuiz1Test() {
-        int level = 1;
         // Given
         when(dockerAPI.getUserImagesAPI(TEST_CONTAINER_PORT)).thenReturn(
                 Mono.just(new Elements.Image[]{
@@ -38,7 +36,7 @@ class QuizServiceTest {
         );
 
         // When
-        Mono<String> result = this.quizService.gradeQuiz1(SESSION_ID, TEST_CONTAINER_PORT, level);
+        Mono<String> result = this.quizService.gradeQuiz1(TEST_CONTAINER_PORT);
 
         StepVerifier.create(result)
                 .expectNext("{\"quizResult\":\"SUCCESS\"}")
@@ -56,7 +54,7 @@ class QuizServiceTest {
                 })
         );
 
-        Mono<String> result = this.quizService.gradeQuiz2(SESSION_ID, TEST_CONTAINER_PORT, userAnswer, level);
+        Mono<String> result = this.quizService.gradeQuiz2(TEST_CONTAINER_PORT, userAnswer);
 
         StepVerifier.create(result)
                 .expectNext("{\"quizResult\":\"SUCCESS\"}")
@@ -66,12 +64,11 @@ class QuizServiceTest {
     @Test
     @DisplayName("이미지 삭제하기 채점 테스트")
     public void GradeQuiz3Test() {
-        int level = 3;
         when(dockerAPI.getUserImagesAPI(TEST_CONTAINER_PORT)).thenReturn(
                 Mono.just(new Elements.Image[]{})
         );
 
-        Mono<String> result = this.quizService.gradeQuiz3(SESSION_ID, TEST_CONTAINER_PORT, level);
+        Mono<String> result = this.quizService.gradeQuiz3(TEST_CONTAINER_PORT);
 
         StepVerifier.create(result)
                 .expectNext("{\"quizResult\":\"SUCCESS\"}")
@@ -81,7 +78,6 @@ class QuizServiceTest {
     @Test
     @DisplayName("컨테이너 생성 채점 테스트")
     public void GradeQuiz4Test() {
-        int level = 4;
         when(dockerAPI.getContainersAPI(TEST_CONTAINER_PORT)).thenReturn(
                 Mono.just(new Elements.Container[]{
                         new Elements.Container("aa86eacfb3b3ed4cd362c1e88fc89a53908ad05fb3a4103bca3f9b28292d14bf",
@@ -89,7 +85,7 @@ class QuizServiceTest {
                 })
         );
 
-        Mono<String> result = this.quizService.gradeQuiz4(SESSION_ID, TEST_CONTAINER_PORT, level);
+        Mono<String> result = this.quizService.gradeQuiz4(TEST_CONTAINER_PORT);
 
         StepVerifier.create(result)
                 .expectNext("{\"quizResult\":\"SUCCESS\"}")
@@ -99,10 +95,9 @@ class QuizServiceTest {
     @Test
     @DisplayName("컨테이너 실행 채점 테스트")
     public void GradeQuiz5Test() {
-        int level = 5;
         String userAnswer = "부스트캠프 웹모바일 9기 화이팅!";
 
-        Mono<String> result = this.quizService.gradeQuiz5(SESSION_ID, userAnswer, level);
+        Mono<String> result = this.quizService.gradeQuiz5(userAnswer);
 
         StepVerifier.create(result)
                 .expectNext("{\"quizResult\":\"SUCCESS\"}")
@@ -112,7 +107,6 @@ class QuizServiceTest {
     @Test
     @DisplayName("컨테이너 생성 및 실행 채점 테스트")
     public void GradeQuiz6Test() {
-        int level = 6;
         when(this.dockerAPI.getContainersAPI(TEST_CONTAINER_PORT)).thenReturn(
                 Mono.just(new Elements.Container[]{
                         new Elements.Container("aa86eacfb3b3ed4cd362c1e88fc89a53908ad05fb3a4103bca3f9b28292d14bf",
@@ -120,7 +114,7 @@ class QuizServiceTest {
                 })
         );
 
-        Mono<String> result = this.quizService.gradeQuiz6(SESSION_ID, TEST_CONTAINER_PORT, level);
+        Mono<String> result = this.quizService.gradeQuiz6(TEST_CONTAINER_PORT);
 
         StepVerifier.create(result)
                 .expectNext("{\"quizResult\":\"SUCCESS\"}")
@@ -130,10 +124,9 @@ class QuizServiceTest {
     @Test
     @DisplayName("컨테이너 로그 확인하기 채점 테스트")
     public void GradeQuiz7Test() {
-        int level = 7;
         String userAnswer = "스페이스바";
 
-        Mono<String> result = this.quizService.gradeQuiz7(SESSION_ID, userAnswer, level);
+        Mono<String> result = this.quizService.gradeQuiz7(userAnswer);
 
         StepVerifier.create(result)
                 .expectNext("{\"quizResult\":\"SUCCESS\"}")
@@ -143,7 +136,6 @@ class QuizServiceTest {
     @Test
     @DisplayName("컨테이너 목록 확인하기 채점 테스트")
     public void GradeQuiz8Test() {
-        int level = 8;
         String userAnswer = "bc23ea";
         when(this.dockerAPI.getContainersAPI(TEST_CONTAINER_PORT)).thenReturn(
             Mono.just(new Elements.Container[]{
@@ -152,7 +144,7 @@ class QuizServiceTest {
             })
         );
 
-        Mono<String> result = this.quizService.gradeQuiz8(SESSION_ID, TEST_CONTAINER_PORT, userAnswer, level);
+        Mono<String> result = this.quizService.gradeQuiz8(TEST_CONTAINER_PORT, userAnswer);
 
         StepVerifier.create(result)
                 .expectNext("{\"quizResult\":\"SUCCESS\"}")
@@ -162,7 +154,6 @@ class QuizServiceTest {
     @Test
     @DisplayName("컨테이너 중지하기 채점 테스트")
     public void GradeQuiz9Test() {
-        int level = 9;
         when(this.dockerAPI.getContainersAPI(TEST_CONTAINER_PORT)).thenReturn(
                 Mono.just(new Elements.Container[]{
                         new Elements.Container("bc23eacfb3b3ed4cd362c1e88fc89a53908ad05fb3a4103bca3f9b28292d14bf",
@@ -170,7 +161,7 @@ class QuizServiceTest {
                 })
         );
 
-        Mono<String> result = this.quizService.gradeQuiz9(SESSION_ID, TEST_CONTAINER_PORT, level);
+        Mono<String> result = this.quizService.gradeQuiz9(TEST_CONTAINER_PORT);
 
         StepVerifier.create(result)
                 .expectNext("{\"quizResult\":\"SUCCESS\"}")
@@ -180,12 +171,11 @@ class QuizServiceTest {
     @Test
     @DisplayName("컨테이너 삭제하기 채점 테스트")
     public void GradeQuiz10Test() {
-        int level = 10;
         when(this.dockerAPI.getContainersAPI(TEST_CONTAINER_PORT)).thenReturn(
                 Mono.just(new Elements.Container[]{})
         );
 
-        Mono<String> result = this.quizService.gradeQuiz10(SESSION_ID, TEST_CONTAINER_PORT, level);
+        Mono<String> result = this.quizService.gradeQuiz10(TEST_CONTAINER_PORT);
 
         StepVerifier.create(result)
                 .expectNext("{\"quizResult\":\"SUCCESS\"}")


### PR DESCRIPTION
# 작업 내용
- `QuizService` `grade`메소드 구현
- `QuizController`에 `submit` API구현
- `Container`객체 만들 시 생성자 매개변수 순서 오류 수정

## 세부 기록
### 1. Redis
#### redis접속
`redis-cli`
#### redis key들 확인
`keys *`
#### Hash형 값 확인
`HGETALL [key]`

### 2. 테스트 코드
문제에 따른 채점 메소드 호출 분기를 담당하는 `grade`메소드를 TDD방식으로 구현하려 했지만, 애매했다. `grade`메소드는 단순히 `switch-case`문으로 분기 처리만 할 뿐 딱히 비즈니스 로직이 포함되어 있지 않기 때문이다. 

결과적으로, 테스트 코드를 작성해야 하는 메소드는 **비즈니스 로직**을 포함하는 메소드에 대해서 작성해야 한다.

